### PR TITLE
Modify DeepPartial to recurse for objects only

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,6 @@
-export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
 export type GeneratorFnOptions<T, I> = {
   sequence: number;
   afterBuild: (fn: HookFn<T>) => any;


### PR DESCRIPTION
This fixes [issue 29](https://github.com/thoughtbot/fishery/issues/29) in [thoughtbot/fishery](https://github.com/thoughtbot/fishery).